### PR TITLE
Migrate to NetworkX 2

### DIFF
--- a/flowgraph/core/graphml.py
+++ b/flowgraph/core/graphml.py
@@ -140,7 +140,7 @@ class GraphMLWriter(BaseGraphMLWriter):
     def add_nodes(self, graph, graph_element, parent_node=None):
         """ Reimplemented to support nested graphs.
         """
-        for node, data in graph.nodes_iter(data=True):
+        for node, data in graph.nodes(data=True):
             # If the node is a reference to the parent graph, skip it.
             # It has already been added.
             if self.is_parent_reference(graph, node):
@@ -186,11 +186,11 @@ class GraphMLWriter(BaseGraphMLWriter):
         """ Reimplemented to support ports.
         
         Unlike the base class, we do not store edge keys as data (or at all).
-        Cf. this PR for unreleased NetworkX 2.0:
+        Cf. this PR for NetworkX 2.0:
         https://github.com/networkx/networkx/pull/2559
         """
         default = graph.graph.get('edge_default', {})
-        for u,v,data in graph.edges_iter(data=True):
+        for u,v,data in graph.edges(data=True):
             source = parent_node if self.is_parent_reference(graph, u) else u
             target = parent_node if self.is_parent_reference(graph, v) else v
             edge_element = Element('edge',
@@ -335,7 +335,7 @@ class GraphMLReader(BaseGraphMLReader):
         elif len(nested_xml) > 1:
             raise nx.NetworkXError("GraphML allows at most one nested graph per node")
         
-        graph.add_node(node_id, data)
+        graph.add_node(node_id, **data)
     
     def add_edge(self, graph, edge_element, graphml_keys, parent_node):
         """ Reimplemented to handle nested graphs and ports.
@@ -372,4 +372,4 @@ class GraphMLReader(BaseGraphMLReader):
         if targetport is not None:
             data['targetport'] = targetport
         
-        graph.add_edge(source, target, attr_dict=data)
+        graph.add_edge(source, target, **data)

--- a/flowgraph/core/graphutil.py
+++ b/flowgraph/core/graphutil.py
@@ -30,8 +30,8 @@ def find_node(graph, query, **kwargs):
 def find_nodes(graph, query, data=False):
     """ Iterator over all nodes matching the data query.
     """
-    return ((v, graph.node[v]) if data else v 
-            for v in graph if query(graph.node[v]))
+    return ((v, graph.nodes[v]) if data else v 
+            for v in graph if query(graph.nodes[v]))
 
 
 def node_name(graph, base=None, sep=None):

--- a/flowgraph/core/tests/test_graphml.py
+++ b/flowgraph/core/tests/test_graphml.py
@@ -42,8 +42,8 @@ class TestGraphMLIO(unittest.TestCase):
             graph.graph.pop('edge_default', None)
         
         self.assertEqual(one.graph, two.graph)
-        self.assertEqual(one.node, two.node)
-        self.assertEqual(one.edge, two.edge)
+        self.assertEqual(one.nodes, two.nodes)
+        self.assertEqual(one.edges, two.edges)
 
     def test_basic_graph(self):
         """ Can we round-trip a basic directed graph?
@@ -90,17 +90,17 @@ class TestGraphMLIO(unittest.TestCase):
         foo_graph.add_node('foo1', kind='foo')
         foo_graph.add_node('foo2', kind='foo')
         foo_graph.add_edge('foo1', 'foo2')
-        graph.node['foo-container']['graph'] = foo_graph
+        graph.nodes['foo-container']['graph'] = foo_graph
         
         bar_graph = nx.DiGraph()
         bar_graph.add_node('bar1', kind='bar')
         bar_graph.add_node('bar2', kind='bar')
         bar_graph.add_edge('bar1', 'bar2')
-        graph.node['bar-container']['graph'] = bar_graph
+        graph.nodes['bar-container']['graph'] = bar_graph
         
         recovered = roundtrip(graph)
-        foo_recovered = recovered.node['foo-container']['graph']
-        bar_recovered = recovered.node['bar-container']['graph']
+        foo_recovered = recovered.nodes['foo-container']['graph']
+        bar_recovered = recovered.nodes['bar-container']['graph']
         self.assert_graphs_equal(foo_recovered, foo_graph)
         self.assert_graphs_equal(bar_recovered, bar_graph)
     
@@ -111,10 +111,10 @@ class TestGraphMLIO(unittest.TestCase):
         graph.add_node('root')
         nested = nx.DiGraph(node='__node__')
         nested.add_path(['__node__', 'n1', 'n2', '__node__'])
-        graph.node['root']['graph'] = nested
+        graph.nodes['root']['graph'] = nested
 
         recovered = roundtrip(graph)
-        nested_recovered = recovered.node['root']['graph']
+        nested_recovered = recovered.nodes['root']['graph']
         self.assert_graphs_equal(nested_recovered, nested)
         
         # The reference node ID should only appear as a graph attribute.
@@ -128,10 +128,10 @@ class TestGraphMLIO(unittest.TestCase):
         graph.add_node('root')
         nested = nx.DiGraph(input_node='__in__', output_node='__out__')
         nested.add_path(['__in__', 'n1', 'n2', '__out__'])
-        graph.node['root']['graph'] = nested
+        graph.nodes['root']['graph'] = nested
 
         recovered = roundtrip(graph)
-        nested_recovered = recovered.node['root']['graph']
+        nested_recovered = recovered.nodes['root']['graph']
         self.assert_graphs_equal(nested_recovered, nested)
         
         # The reference node IDs should only appear as graph attributes.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup_args = {
         'traitlets',
         'requests',
         'jsonpickle',
-        'networkx==1.11',
+        'networkx>=2.0',
         'cachetools>=2.0.0',
         'blitzdb>=0.3',
         'sqlalchemy',


### PR DESCRIPTION
A long list of tiny changes to support NetworkX 2 (#1).

NetworkX 1.1 is no longer supported.