### PR TITLE
Python 2.7 compatibility fixes

### DIFF
--- a/flowgraph/core/tests/test_flow_graph.py
+++ b/flowgraph/core/tests/test_flow_graph.py
@@ -823,9 +823,12 @@ class TestFlowGraph(unittest.TestCase):
         outer = flow_graph_to_graphml(self.builder.graph)
         root = list(outer.nodes)[0]
         graph, ports = outer.nodes[root]['graph'], outer.nodes[root]['ports']
+        # FIXME: Outputs ports should have a deterministic order.
+        sorted_ports = sorted(ports.values(),
+                              key=lambda d: d['annotation'], reverse=True)
         outputs = { data['id'] for _, _, data in
                     graph.in_edges(graph.graph['output_node'], data=True) }
-        self.assertEqual(list(ports.values()), [
+        self.assertEqual(sorted_ports, [
             {
                 'portkind': 'output',
                 'annotation': 'python/flowgraph/foo',

--- a/flowgraph/integration_tests/data/statsmodels_regression.py
+++ b/flowgraph/integration_tests/data/statsmodels_regression.py
@@ -4,7 +4,7 @@ import statsmodels.api as sm
 import statsmodels.formula.api as smf
 
 # Load data
-dat = sm.datasets.get_rdataset('Guerry', 'HistData', cache=True).data
+dat = sm.datasets.get_rdataset('Guerry', 'HistData').data
 
 # Fit regression model (using the natural log of one of the regressors)
 results = smf.ols('Lottery ~ Literacy + np.log(Pop1831)', data=dat).fit()

--- a/flowgraph/integration_tests/test_flow_graph.py
+++ b/flowgraph/integration_tests/test_flow_graph.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 import os
 from pathlib2 import Path
+import six
 import unittest
 
 import networkx as nx
@@ -135,6 +136,7 @@ class IntegrationTestFlowGraph(unittest.TestCase):
                         sourceport='__return__', targetport='data')
         self.assert_isomorphic(graph, target)
     
+    @unittest.skipUnless(six.PY3, "pd.read_csv needs Py2-compatible annotation")
     def test_sklearn_clustering_kmeans(self):
         """ K-means clustering on the Iris dataset using sklearn.
         """
@@ -181,7 +183,9 @@ class IntegrationTestFlowGraph(unittest.TestCase):
                         annotation='python/sklearn/fit-predict-clustering')
         target.add_node('agglom', qual_name='AgglomerativeClustering.__init__',
                         annotation='python/sklearn/agglomerative')
-        target.add_node('fit_agglom', qual_name='ClusterMixin.fit_predict',
+        target.add_node('fit_agglom',
+                        qual_name=('ClusterMixin' if six.PY3 else
+                            'AgglomerativeClustering') + '.fit_predict',
                         annotation='python/sklearn/fit-predict-clustering')
         target.add_node('score', qual_name='mutual_info_score')
         target.add_edge('kmeans', 'fit_kmeans',
@@ -204,6 +208,7 @@ class IntegrationTestFlowGraph(unittest.TestCase):
                         annotation='python/numpy/ndarray')
         self.assert_isomorphic(graph, target)
     
+    @unittest.skipUnless(six.PY3, "pd.read_csv needs Py2-compatible annotation")
     def test_sklearn_regression_metrics(self):
         """ Errors metrics for linear regression using sklearn.
         """
@@ -260,9 +265,11 @@ class IntegrationTestFlowGraph(unittest.TestCase):
                         annotation='python/statsmodels/get-r-dataset')
         target.add_node('read-get', qual_name='Dataset.__getattribute__',
                         annotation='python/statsmodels/dataset', slot='data')
-        target.add_node('ols', qual_name='Model.from_formula',
+        target.add_node('ols',
+                        qual_name=('Model' if six.PY3 else 'OLS') + '.from_formula',
                         annotation='python/statsmodels/ols-from-formula')
-        target.add_node('fit', qual_name='RegressionModel.fit',
+        target.add_node('fit',
+                        qual_name=('RegressionModel' if six.PY3 else 'OLS') + '.fit',
                         annotation='python/statsmodels/fit')
         target.add_edge('read', 'read-get',
                         sourceport='__return__', targetport='self',

--- a/flowgraph/trace/frame_util.py
+++ b/flowgraph/trace/frame_util.py
@@ -24,7 +24,7 @@ import types
 def get_class_module(typ):
     """ Get name of module in which type was defined.
     """
-    return _apply_spec(typ.__module__)
+    return _fix_module_name(typ.__module__)
 
 def get_class_qual_name(typ):
     """ Get qualified name of class.
@@ -50,7 +50,7 @@ def get_class_full_name(typ):
 def get_func_module(func):
     """ Get name of module in which the function object was defined.
     """
-    return _apply_spec(func.__module__)
+    return _fix_module_name(func.__module__)
 
 def get_func_qual_name(func):
     """ Get the qualified name of a function object.
@@ -98,7 +98,7 @@ def get_frame_module(frame):
     except KeyError:
         # Some frames, e.g. calls of IPython magics, belong to no module.
         name = None
-    return _apply_spec(name)
+    return _fix_module_name(name)
 
 def get_frame_func(frame, raise_on_ambiguous=True):
     """ Get the function/method object of the called function in a frame.
@@ -151,13 +151,18 @@ def get_frame_arguments(frame):
     return args
 
 
-def _apply_spec(name):
-    """ Hack to replace __main__ with correct module name.
-    
-    See PEP 451: "A ModuleSpec Type for the Import System"
+def _fix_module_name(name):
+    """ Fix up name of Python module.
     """
+    # Python 2 only: use 'builtins' for consistency with Python 3.
+    if name == '__builtin__':
+        name = 'builtins'
+    
+    # Hack to replace __main__ with correct module name.
+    # See PEP 451: "A ModuleSpec Type for the Import System"
     if name == '__main__':
         spec = getattr(sys.modules['__main__'], '__spec__', None)
         if spec is not None:
             name = spec.name
+
     return name

--- a/flowgraph/trace/tracer.py
+++ b/flowgraph/trace/tracer.py
@@ -169,5 +169,17 @@ class Tracer(HasTraits):
         if module.startswith('flowgraph.trace') and not 'tests' in module:
             return False
         
+        # The final test is an explicit blacklist of functions to ignore. 
+        if qual_name in trace_blacklist:
+            return False
+        
         # By default, trace the function.
         return True
+
+
+trace_blacklist = set([
+    # Python 2 only: extensions of import system due to `pkg_resources` and
+    # `six` packages.
+    '_SixMetaPathImporter.find_module',
+    'VendorImporter.find_module',
+])


### PR DESCRIPTION
Fixes #3.

The problems with the integration tests are mostly related to the non-existence of qualified names in Python 2 (see [PEP 3155](https://www.python.org/dev/peps/pep-3155/)). At some point we need to get our story straight on this issue, but that's out of scope for this PR.