### PR TITLE
Simple CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@
 
 **Record dataflow graphs of Python programs using dynamic program analysis.**
 
-The package can be used standalone but is designed primarily to be used in conjunction with our [semantic analysis](https://github.com/IBM/semanticflowgraph) tools. The main use case is analyzing short scripts in data science and scientific computing. This package is not appropriate for analyzing large-scale industrial software.
+The package can be used standalone but is designed primarily to be used in
+conjunction with our [semantic flow
+graphs](https://github.com/IBM/semanticflowgraph). The main use case is
+analyzing short scripts in data science and scientific computing. This package
+is not appropriate for analyzing large-scale industrial software.
 
 This is **alpha** software. Contributions are welcome!
+
+## Command-line interface
+
+The package ships with a minimal CLI, invokable as `python -m flowgraph`.
+You can use the CLI to run and record a Python script as a raw flow graph.
+
+```
+python -m flowgraph input.py --out output.graphml
+```
+
+For a more comprehensive CLI, with support for recording, semantic enrichment,
+and visualization of flow graphs, see the Julia package for [semantic flow
+graphs](https://github.com/IBM/semanticflowgraph).

--- a/flowgraph/__main__.py
+++ b/flowgraph/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2018 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from .cli import cli
+
+
+if __name__ == '__main__':
+    cli.main(prog_name='pyflowgraph')

--- a/flowgraph/cli.py
+++ b/flowgraph/cli.py
@@ -21,8 +21,6 @@ import sys
 
 import click
 
-from .core.flow_graph import flow_graph_to_graphml
-from .core.graphml import write_graphml
 from .core.record import record_code
 
 
@@ -31,7 +29,5 @@ from .core.record import record_code
 @click.option('-o', '--out', type=click.File('wb'))
 def cli(script, out):
     code = script.read()
-    graph = record_code(code)
-
     out = out or (sys.stdout.buffer if six.PY3 else sys.stdout)
-    write_graphml(flow_graph_to_graphml(graph), out)
+    graph = record_code(code, out=out)

--- a/flowgraph/cli.py
+++ b/flowgraph/cli.py
@@ -1,0 +1,37 @@
+# Copyright 2018 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Command-line interface to pyflowgraph.
+"""
+from __future__ import absolute_import
+
+import six
+import sys
+
+import click
+
+from .core.flow_graph import flow_graph_to_graphml
+from .core.graphml import write_graphml
+from .core.record import record_code
+
+
+@click.command()
+@click.argument('script', type=click.File('r'))
+@click.option('-o', '--out', type=click.File('wb'))
+def cli(script, out):
+    code = script.read()
+    graph = record_code(code)
+
+    out = out or (sys.stdout.buffer if six.PY3 else sys.stdout)
+    write_graphml(flow_graph_to_graphml(graph), out)

--- a/flowgraph/core/flow_graph.py
+++ b/flowgraph/core/flow_graph.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Operations on flow graphs.
+""" Create and manipulate flow graphs.
 
-This module contains functions that create empty flow graphs and operate on
+This module contains functions that create empty flow graphs and manipulate
 existing flow graphs. To create a new flow graph by tracing Python code, see the
-`flow_graph_builder` module.
+`flow_graph_builder` and `record` modules.
 
 These graphs are sometimes called "concrete" or "raw" flow graphs to
 distinguish them from other dataflow graphs in the Open Discovery system.

--- a/flowgraph/core/flow_graph_builder.py
+++ b/flowgraph/core/flow_graph_builder.py
@@ -61,8 +61,7 @@ class FlowGraphBuilder(HasTraits):
     def graph(self):
         """ Top-level flow graph.
         """
-        # Make a shallow copy.
-        return nx.MultiDiGraph(self._stack[0].graph)
+        return self._stack[0].graph
     
     def push_event(self, event):
         """ Push a new TraceEvent to the builder.

--- a/flowgraph/core/record.py
+++ b/flowgraph/core/record.py
@@ -1,0 +1,55 @@
+# Copyright 2018 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Record flow graphs by running Python code.
+
+This module is a convenient entry point for users of the package, wrapping
+the `FlowGraphBuilder` and `Tracer` into easy-to-use functions.
+"""
+from __future__ import absolute_import
+
+from traitlets import HasTraits, Instance
+
+from flowgraph.trace.tracer import Tracer
+from .flow_graph_builder import FlowGraphBuilder
+
+
+class Recorder(HasTraits):
+    """ Context manager to record flow graphs.
+
+    Like all context managers, this class should be used in a `with` statement::
+
+        with Recorder() as graph:
+            [...]
+    """
+    builder = Instance(FlowGraphBuilder)
+    tracer = Instance(Tracer)
+
+    # Context manager interface
+    
+    def __enter__(self):
+        self.tracer.observe(self._handle_trace_event, 'event')
+        self.tracer.enable()
+        return self.builder.graph
+        
+    def __exit__(self, type, value, traceback):
+        self.tracer.disable()
+        self.tracer.unobserve(self._handle_trace_event, 'event')
+
+    # Handlers
+
+    def _handle_trace_event(self, changed):
+        event = changed['new']
+        if event:
+            self.builder.push_event(event)

--- a/flowgraph/core/record.py
+++ b/flowgraph/core/record.py
@@ -47,7 +47,7 @@ def record_code(code, out=None, env=None, cwd=None, db=None, **kwargs):
     cwd : str (optional)
         Current working directory in which to evaluate code
     
-    db : AnnotatioDB (optional)
+    db : AnnotationDB (optional)
         Annotation database, by default the standard remoate annotation DB
 
     **kwargs
@@ -102,7 +102,10 @@ class Recorder(HasTraits):
     Like all context managers, this class should be used in a `with` statement::
 
         with Recorder() as graph:
-            [...]
+            from sklearn.datasets import make_blobs
+            X, labels = make_blobs(n_samples=100, n_features=2, centers=3)
+
+    For most use cases, it is simpler to use `record_code` or `record_script`.
     """
     builder = Instance(FlowGraphBuilder)
     tracer = Instance(Tracer)

--- a/flowgraph/core/record.py
+++ b/flowgraph/core/record.py
@@ -24,17 +24,22 @@ import os
 from traitlets import HasTraits, Instance
 
 from flowgraph.trace.tracer import Tracer
+from .flow_graph import flow_graph_to_graphml
 from .flow_graph_builder import FlowGraphBuilder
+from .graphml import write_graphml
 from .remote_annotation_db import RemoteAnnotationDB
 
 
-def record_code(code, env=None, cwd=None, db=None, **kwargs):
+def record_code(code, out=None, env=None, cwd=None, db=None, **kwargs):
     """ Evaluate and record Python code.
 
     Parameters
     ----------
     code : str or code object
         Python code to record
+    
+    out : str or file-like object (optional)
+        Filename or file to which recorded flow graph is written (as GraphML)
     
     env : dict (optional)
         Environment in which to evaluate code
@@ -66,12 +71,15 @@ def record_code(code, env=None, cwd=None, db=None, **kwargs):
     finally:
         if cwd is not None:
             os.chdir(oldcwd)
+    
+    if out is not None:
+        write_graphml(flow_graph_to_graphml(graph), out)
 
     return graph
 
 
 def record_script(filename, **kwargs):
-    """ Evaluate and record Python script.
+    """ Evaluate and record a Python script.
 
     Parameters
     ----------

--- a/flowgraph/tests/data/sklearn_make_blobs.py
+++ b/flowgraph/tests/data/sklearn_make_blobs.py
@@ -1,0 +1,3 @@
+from sklearn.datasets import make_blobs
+
+X, labels = make_blobs(n_samples=100, n_features=2, centers=3)

--- a/flowgraph/tests/test_cli.py
+++ b/flowgraph/tests/test_cli.py
@@ -1,0 +1,41 @@
+# Copyright 2018 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from pathlib2 import Path
+import unittest
+
+from click.testing import CliRunner
+
+from ..core.flow_graph import flow_graph_from_graphml
+from ..core.graphml import read_graphml_str
+from ..cli import cli
+
+data_path = Path(__file__).parent.joinpath('data')
+
+
+class TestCLI(unittest.TestCase):
+    """ Test the command-line interface to pyflowgraph.
+    """
+    
+    def test_record_file(self):
+        """ Test that a file can be recorded using the CLI.
+        """
+        filename = str(data_path.joinpath('sklearn_make_blobs.py'))
+        runner = CliRunner()
+        result = runner.invoke(cli, [filename])
+        xml = result.output
+        graph = flow_graph_from_graphml(read_graphml_str(xml))
+        self.assertGreater(len(graph), 0)

--- a/flowgraph/trace/tracer.py
+++ b/flowgraph/trace/tracer.py
@@ -164,9 +164,10 @@ class Tracer(HasTraits):
         
         # No interference from this package.
         # Calls that can be picked up include:
+        #   - Recorder.__exit__
         #   - Tracer.__exit__
         #   - Garbage collection callback from ObjectTracker
-        if module.startswith('flowgraph.trace') and not 'tests' in module:
+        if module.startswith('flowgraph') and not 'tests' in module:
             return False
         
         # The final test is an explicit blacklist of functions to ignore. 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup_args = {
         'traitlets',
         'requests',
         'jsonpickle',
+        'click',
         'networkx>=2.0',
         'cachetools>=2.0.0',
         'blitzdb>=0.3',


### PR DESCRIPTION
The simplest possible command-line interface: converts a Python script to raw flow graph in GraphML format.

The more important addition is the `record_code` and `record_script` functions, which tie together all the components in an easy-to-use form, suitable for consumption by other libraries and tools.