### PR TITLE
Static tracking of variable access, assignment, and deletion

### DIFF
--- a/flowgraph/core/flow_graph_builder.py
+++ b/flowgraph/core/flow_graph_builder.py
@@ -28,7 +28,8 @@ from flowgraph.trace import operator as extra_operator
 from flowgraph.trace.inspect_name import get_class_module_name, \
     get_class_qual_name
 from flowgraph.trace.object_tracker import ObjectTracker
-from flowgraph.trace.trace_event import TraceEvent, TraceCall, TraceReturn
+from flowgraph.trace.trace_event import TraceEvent, TraceCall, TraceReturn, \
+    TraceAccess, TraceAssign
 from .annotator import Annotator
 from .flow_graph import new_flow_graph
 
@@ -81,6 +82,10 @@ class FlowGraphBuilder(HasTraits):
             self._push_call_event(event)
         elif isinstance(event, TraceReturn):
             self._push_return_event(event)
+        elif isinstance(event, TraceAccess):
+            self._push_access_event(event)
+        elif isinstance(event, TraceAssign):
+            self._push_assign_event(event)
     
     def reset(self):
         """ Reset the flow graph builder.
@@ -235,6 +240,30 @@ class FlowGraphBuilder(HasTraits):
         
         # Update node and port data for this call.
         self._update_call_node_for_return(event, annotation, node)
+    
+    def _push_access_event(self, event):
+        """ Update event table for variable access event.
+        """
+        context = self._stack[-1]
+        source = context.variable_table.get(event.name)
+        if source is not None:
+            context.event_table[event] = source
+    
+    def _push_assign_event(self, event):
+        """ Update variable table for variable assign event.
+        """
+        context = self._stack[-1]
+        obj = event.value
+        obj_id = self.object_tracker.get_id(obj)
+        source = None
+        if obj_id:
+            source = context.output_table[obj_id]
+        elif event.value_event:
+            source = context.event_table.get(event.value_event)
+        
+        if source is not None:
+            for name in event.names:
+                context.variable_table[name] = source
         
     def _add_call_node(self, event, annotation):
         """ Add a new call node for a call event.
@@ -567,12 +596,18 @@ class _CallContext(HasTraits):
     # it improves efficiency by allowing constant-time lookup.
     output_table = Dict()
 
+    # Variable table: mapping from variable names to (node, output port) pair.
+    #
+    # A complement to object tracking, which doesn't work for objects that
+    # are not weak referenceable.
+    variable_table = Dict()
+
     # Event table: mapping from trace event to (node, output port) pair.
     #
-    # As a complement to object tracking, which doesn't always work, we
-    # maintain a correspondence between `TraceValueEvent`s and their outputs.
-    # The dictionary has weak reference keys because we want to allow the trace
-    # events to be garbage collected once they've passed through the system.
+    # Like the variable table, the event table is only relevant for objects
+    # that can't be tracked. The dictionary has weak reference keys because we
+    # want to allow the trace events to be garbage collected once they've
+    # passed through the system.
     event_table = Instance(WeakKeyDictionary, ())
 
 

--- a/flowgraph/core/flow_graph_builder.py
+++ b/flowgraph/core/flow_graph_builder.py
@@ -75,14 +75,12 @@ class FlowGraphBuilder(HasTraits):
         return nx.MultiDiGraph(self._stack[0].graph)
     
     def push_event(self, event):
-        """ Push a new TraceEvent to the builder.
+        """ Push a new trace event to the builder.
         """
         if isinstance(event, TraceCall):
             self._push_call_event(event)
         elif isinstance(event, TraceReturn):
             self._push_return_event(event)
-        else:
-            raise TypeError("Event must be TraceCall or TraceReturn")
     
     def reset(self):
         """ Reset the flow graph builder.

--- a/flowgraph/core/flow_graph_builder.py
+++ b/flowgraph/core/flow_graph_builder.py
@@ -78,16 +78,11 @@ class FlowGraphBuilder(HasTraits):
     def push_event(self, event):
         """ Push a new trace event to the builder.
         """
-        if isinstance(event, TraceCall):
-            self._push_call_event(event)
-        elif isinstance(event, TraceReturn):
-            self._push_return_event(event)
-        elif isinstance(event, TraceAccess):
-            self._push_access_event(event)
-        elif isinstance(event, TraceAssign):
-            self._push_assign_event(event)
-        elif isinstance(event, TraceDelete):
-            self._push_delete_event(event)
+        if isinstance(event, TraceCall): self._push_call_event(event)
+        elif isinstance(event, TraceReturn): self._push_return_event(event)
+        elif isinstance(event, TraceAccess): self._push_access_event(event)
+        elif isinstance(event, TraceAssign): self._push_assign_event(event)
+        elif isinstance(event, TraceDelete): self._push_delete_event(event)
     
     def reset(self):
         """ Reset the flow graph builder.
@@ -162,8 +157,9 @@ class FlowGraphBuilder(HasTraits):
         returning a tuple. We treat tuples as multiple returns, subject to a
         few special exceptions.
         """
-        return isinstance(event.value, tuple) and \
-            event.function not in (getattr, extra_operator.__tuple__)
+        return (event.nvalues > 1 or 
+                (isinstance(event.value, tuple) and 
+                 event.function not in (getattr, extra_operator.__tuple__)))
     
     # Protected interface
             

--- a/flowgraph/core/flow_graph_builder.py
+++ b/flowgraph/core/flow_graph_builder.py
@@ -29,7 +29,7 @@ from flowgraph.trace.inspect_name import get_class_module_name, \
     get_class_qual_name
 from flowgraph.trace.object_tracker import ObjectTracker
 from flowgraph.trace.trace_event import TraceEvent, TraceCall, TraceReturn, \
-    TraceAccess, TraceAssign
+    TraceAccess, TraceAssign, TraceDelete
 from .annotator import Annotator
 from .flow_graph import new_flow_graph
 
@@ -86,6 +86,8 @@ class FlowGraphBuilder(HasTraits):
             self._push_access_event(event)
         elif isinstance(event, TraceAssign):
             self._push_assign_event(event)
+        elif isinstance(event, TraceDelete):
+            self._push_delete_event(event)
     
     def reset(self):
         """ Reset the flow graph builder.
@@ -264,6 +266,13 @@ class FlowGraphBuilder(HasTraits):
         if source is not None:
             for name in event.names:
                 context.variable_table[name] = source
+    
+    def _push_delete_event(self, event):
+        """ Clean variable table in response to variable deletion event.
+        """
+        context = self._stack[-1]
+        for name in event.names:
+            context.variable_table.pop(name, None)
         
     def _add_call_node(self, event, annotation):
         """ Add a new call node for a call event.

--- a/flowgraph/core/tests/test_flow_graph.py
+++ b/flowgraph/core/tests/test_flow_graph.py
@@ -393,6 +393,16 @@ class TestFlowGraph(unittest.TestCase):
         self.assertEqual(port_data['qual_name'], 'module')
         self.assertEqual(port_data['value'], objects.__name__)
     
+    def test_variable_deletion(self):
+        """ Test that deleting a variable doesn't break anything.
+        """
+        actual = self.record("""
+            x = 1
+            del x
+        """)
+        target = new_flow_graph()
+        self.assert_isomorphic(actual, target)
+    
     def test_primitive_values(self):
         """ Test that primitive values passed by variables are recorded.
         """

--- a/flowgraph/core/tests/test_flow_graph.py
+++ b/flowgraph/core/tests/test_flow_graph.py
@@ -413,7 +413,6 @@ class TestFlowGraph(unittest.TestCase):
         target.add_edge('new_foo', outputs, sourceport='__return__')
         self.assert_isomorphic(actual, target, check_id=False)
     
-    @unittest.skip("Static analysis for sequence literals not implemented")
     def test_track_inside_list(self):
         """ Test a function call with tracked objects inside a list.
         """
@@ -426,15 +425,17 @@ class TestFlowGraph(unittest.TestCase):
         
         target = new_flow_graph()
         outputs = target.graph['output_node']
-        target.add_node('1', qual_name='Foo')
-        target.add_node('2', qual_name='Foo')
-        target.add_node('3', qual_name='foo_x_sum')
-        target.add_edge('1', '3', id=self.id('foo1'),
-                        sourceport='__return__', targetport='foos')
-        target.add_edge('2', '3', id=self.id('foo2'),
-                        sourceport='__return__', targetport='foos')
-        target.add_edge('1', outputs, id=self.id('foo1'), sourceport='__return__')
-        target.add_edge('2', outputs, id=self.id('foo2'), sourceport='__return__')
+        target.add_node('foo1', qual_name='Foo')
+        target.add_node('foo2', qual_name='Foo')
+        target.add_node('list', qual_name='__list__')
+        target.add_node('foo_x_sum', qual_name='foo_x_sum')
+        target.add_edge('foo1', 'list', id=self.id('foo1'),
+                        sourceport='__return__', targetport='0')
+        target.add_edge('foo2', 'list', id=self.id('foo2'),
+                        sourceport='__return__', targetport='1')
+        target.add_edge('list', 'foo_x_sum', sourceport='__return__', targetport='foos')
+        target.add_edge('foo1', outputs, id=self.id('foo1'), sourceport='__return__')
+        target.add_edge('foo2', outputs, id=self.id('foo2'), sourceport='__return__')
         self.assert_isomorphic(actual, target)
     
     def test_function_annotations(self):

--- a/flowgraph/integration_tests/data/numpy_meshgrid.py
+++ b/flowgraph/integration_tests/data/numpy_meshgrid.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+xx, yy = np.meshgrid(np.linspace(-3, 3, 500),
+                     np.linspace(-3, 3, 500))

--- a/flowgraph/integration_tests/test_flow_graph.py
+++ b/flowgraph/integration_tests/test_flow_graph.py
@@ -96,6 +96,29 @@ class IntegrationTestFlowGraph(unittest.TestCase):
         
         return graph
     
+    def test_numpy_meshgrid(self):
+        """ Create two-dimensional grid using NumPy's `meshgrid`.
+        """
+        graph = self.record_script("numpy_meshgrid")
+        target = new_flow_graph()
+        outputs = target.graph['output_node']
+        target.add_node('lin1', qual_name='linspace')
+        target.add_node('lin2', qual_name='linspace')
+        target.add_node('meshgrid', qual_name='meshgrid')
+        target.add_edge('lin1', 'meshgrid', sourceport='__return__', targetport='0',
+                        annotation='python/numpy/ndarray')
+        target.add_edge('lin2', 'meshgrid', sourceport='__return__', targetport='1',
+                        annotation='python/numpy/ndarray')
+        target.add_edge('lin1', outputs, sourceport='__return__',
+                        annotation='python/numpy/ndarray')
+        target.add_edge('lin2', outputs, sourceport='__return__',
+                        annotation='python/numpy/ndarray')
+        target.add_edge('meshgrid', outputs, sourceport='__return__.0',
+                        annotation='python/numpy/ndarray')
+        target.add_edge('meshgrid', outputs, sourceport='__return__.1',
+                        annotation='python/numpy/ndarray')
+        self.assert_isomorphic(graph, target)
+    
     def test_numpy_reshape(self):
         """ Reshape a NumPy array.
         """

--- a/flowgraph/trace/ast_transform.py
+++ b/flowgraph/trace/ast_transform.py
@@ -246,12 +246,12 @@ class OperatorsToFunctions(ast.NodeTransformer):
             return to_call(self.op_to_function(op), [node.left, comparator])
 
 
-class ContainerLiteralsToFunction(ast.NodeTransformer):
+class ContainerLiteralsToFunctions(ast.NodeTransformer):
     """ Replace container literals with function calls.
     """
 
     def __init__(self, operator_module=None):
-        super(ContainerLiteralsToFunction, self).__init__()
+        super(ContainerLiteralsToFunctions, self).__init__()
         self.operator = to_name(operator_module or 'operator')
     
     def visit_List(self, node):
@@ -319,6 +319,16 @@ def to_name_constant(value):
         return ast.NameConstant(value)
     else:
         return to_name(str(value))
+
+def to_list(elts, ctx=None):
+    """ Create a List AST node.
+    """
+    return ast.List(list(elts), ctx or ast.Load())
+
+def to_tuple(elts, ctx=None):
+    """ Create a Tuple AST node.
+    """
+    return ast.Tuple(list(elts), ctx or ast.Load())
 
 def set_ctx(node, ctx=None):
     """ Replace AST context without mutation.

--- a/flowgraph/trace/tests/test_ast_tracer.py
+++ b/flowgraph/trace/tests/test_ast_tracer.py
@@ -253,7 +253,7 @@ class LoggingASTTracer(ASTTracer):
         )
         return arg_value
     
-    def _trace_return(self, return_value):
+    def _trace_return(self, return_value, nvalues=1):
         self.call_history.append(('return', return_value))
         return return_value
     

--- a/flowgraph/trace/tests/test_ast_tracer.py
+++ b/flowgraph/trace/tests/test_ast_tracer.py
@@ -210,6 +210,31 @@ class TestASTTracer(unittest.TestCase):
         ])
         self.assertEqual(env['x'], 0)
         self.assertEqual(env['y'], 1)
+    
+    def test_trace_var_delete(self):
+        """ Can we trace a variable deletion?
+        """
+        node = ast.parse('del x')
+        ASTTraceTransformer('__trace__').visit(node)
+        
+        env = self.exec_ast(node, env={'x': 1})
+        self.assertEqual(self.var_history, [
+            ('delete', ['x'])
+        ])
+        self.assertNotIn('x', env)
+    
+    def test_trace_var_multiple_delete(self):
+        """ Can we trace a multiple variable deletion?
+        """
+        node = ast.parse('del x, y')
+        ASTTraceTransformer('__trace__').visit(node)
+        
+        env = self.exec_ast(node, env={'x': 0, 'y': 1})
+        self.assertEqual(self.var_history, [
+            ('delete', ['x','y'])
+        ])
+        self.assertNotIn('x', env)
+        self.assertNotIn('y', env)
 
 
 class LoggingASTTracer(ASTTracer):
@@ -239,6 +264,9 @@ class LoggingASTTracer(ASTTracer):
     def _trace_assign(self, names, value):
         self.var_history.append(('write', names, value))
         return value
+
+    def _trace_delete(self, names):
+        self.var_history.append(('delete', names))
 
 
 if __name__ == '__main__':

--- a/flowgraph/trace/tests/test_ast_transform.py
+++ b/flowgraph/trace/tests/test_ast_transform.py
@@ -210,7 +210,7 @@ class TestASTTransform(unittest.TestCase):
         """ Can we replace a list literal with a function call?
         """
         node = ast.parse('[1,2,3]')
-        ContainerLiteralsToFunction().visit(node)
+        ContainerLiteralsToFunctions().visit(node)
         result = 'operator.__list__(1, 2, 3)'
         self.assertEqual(to_source(node).strip(), result)
     
@@ -218,7 +218,7 @@ class TestASTTransform(unittest.TestCase):
         """ Can we replace a tuple literal with a function call?
         """
         node = ast.parse('(1,2,3)')
-        ContainerLiteralsToFunction().visit(node)
+        ContainerLiteralsToFunctions().visit(node)
         result = 'operator.__tuple__(1, 2, 3)'
         self.assertEqual(to_source(node).strip(), result)
     
@@ -226,7 +226,7 @@ class TestASTTransform(unittest.TestCase):
         """ Can we replace a set literal with a function call?
         """
         node = ast.parse('{1,2,3}')
-        ContainerLiteralsToFunction().visit(node)
+        ContainerLiteralsToFunctions().visit(node)
         result = 'operator.__set__(1, 2, 3)'
         self.assertEqual(to_source(node).strip(), result)
     
@@ -235,7 +235,7 @@ class TestASTTransform(unittest.TestCase):
         function call?
         """
         node = ast.parse("{'x': 1, 'y': 2}")
-        ContainerLiteralsToFunction().visit(node)
+        ContainerLiteralsToFunctions().visit(node)
         result = 'dict(x=1, y=2)'
         self.assertEqual(to_source(node).strip(), result)
 

--- a/flowgraph/trace/tests/test_tracer.py
+++ b/flowgraph/trace/tests/test_tracer.py
@@ -244,6 +244,20 @@ class TestTracer(unittest.TestCase):
         self.assertEqual(event.value, env['foo'])
         self.assertIsInstance(event.value_event, TraceReturn)
         self.assertEqual(event.value_event.function, objects.Foo)
+        self.assertEqual(event.value_event.nvalues, 1)
+
+    def test_variable_compound_assign_boxed_return(self):
+        """ Can the tracer pass boxed return values to a compound assignment?
+        """
+        env = self.trace('foo, bar = objects.create_foo_and_bar()')
+
+        events = self.variable_events
+        event = next(evt for evt in events if isinstance(evt, TraceAssign))
+        self.assertEqual(event.names, [('foo','bar')])
+        self.assertEqual(event.value, (env['foo'],env['bar']))
+        self.assertIsInstance(event.value_event, TraceReturn)
+        self.assertEqual(event.value_event.function, objects.create_foo_and_bar)
+        self.assertEqual(event.value_event.nvalues, 2)
     
     def test_variable_assign_boxed_access(self):
         """ Can the tracer pass boxed variable values to variable assignments?

--- a/flowgraph/trace/tests/test_tracer.py
+++ b/flowgraph/trace/tests/test_tracer.py
@@ -22,7 +22,7 @@ import unittest
 
 from flowgraph.core.tests import objects
 from ..trace_event import TraceFunctionEvent, TraceCall, TraceReturn, \
-    TraceAccess, TraceAssign
+    TraceAccess, TraceAssign, TraceDelete
 from ..tracer import Tracer
 
 
@@ -60,7 +60,7 @@ class TestTracer(unittest.TestCase):
     def filter_trace_variable_event(self, event):
         """ Whether to save trace event related to variables.
         """
-        return isinstance(event, (TraceAccess, TraceAssign))
+        return isinstance(event, (TraceAccess, TraceAssign, TraceDelete))
     
     def trace(self, code, env=None):
         """ Trace code in environment with test objects.
@@ -216,7 +216,6 @@ class TestTracer(unittest.TestCase):
 
         events = self.variable_events
         self.assertEqual(len(events), 1)
-
         event = events[0]
         self.assertIsInstance(event, TraceAccess)
         self.assertEqual(event.name, 'x')
@@ -229,7 +228,6 @@ class TestTracer(unittest.TestCase):
 
         events = self.variable_events
         self.assertEqual(len(events), 1)
-
         event = events[0]
         self.assertIsInstance(event, TraceAssign)
         self.assertEqual(event.names, ['x'])
@@ -257,6 +255,17 @@ class TestTracer(unittest.TestCase):
         self.assertIsInstance(events[0], TraceAccess)
         self.assertIsInstance(events[1], TraceAssign)
         self.assertEqual(events[1].value_event, events[0])
+    
+    def test_variable_delete(self):
+        """ Are variable deletions traced?
+        """
+        self.trace('del x', env={'x': 1})
+
+        events = self.variable_events
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertIsInstance(event, TraceDelete)
+        self.assertEqual(event.names, ['x'])
         
 
 

--- a/flowgraph/trace/tests/test_tracer.py
+++ b/flowgraph/trace/tests/test_tracer.py
@@ -21,7 +21,8 @@ import types
 import unittest
 
 from flowgraph.core.tests import objects
-from ..trace_event import TraceFunctionEvent, TraceCall, TraceReturn
+from ..trace_event import TraceFunctionEvent, TraceCall, TraceReturn, \
+    TraceAccess, TraceAssign
 from ..tracer import Tracer
 
 
@@ -33,27 +34,39 @@ class TestTracer(unittest.TestCase):
         """ Create the tracer and set a handler for trace events.
         """
         self.tracer = Tracer()        
-        self.events = []
+        self.function_events = []
+        self.variable_events = []
         def handler(changed):
             event = changed['new']
-            if event and self.filter_trace_event(event):
-                self.events.append(event)
+            if self.filter_trace_function_event(event):
+                self.function_events.append(event)
+            elif self.filter_trace_variable_event(event):
+                self.variable_events.append(event)
         self.tracer.observe(handler, 'event')
     
-    def filter_trace_event(self, event):
-        """ Whether to keep trace event.
+    def filter_trace_function_event(self, event):
+        """ Whether to save trace event related to function calls.
         """
-        if isinstance(event, TraceFunctionEvent) and event.function is getattr:
+        if not isinstance(event, TraceFunctionEvent):
+            return False
+
+        if event.function is getattr:
             # Ignore attribute access on modules.
-            first_arg = next(iter(event.arguments.values()))
+            first_arg = list(event.arguments.values())[0]
             return not isinstance(first_arg, types.ModuleType)
 
         return True
     
-    def trace(self, code):
+    def filter_trace_variable_event(self, event):
+        """ Whether to save trace event related to variables.
+        """
+        return isinstance(event, (TraceAccess, TraceAssign))
+    
+    def trace(self, code, env=None):
         """ Trace code in environment with test objects.
         """
-        env = dict(objects=objects)
+        env = env or {}
+        env.update(dict(objects=objects))
         return self.tracer.trace(dedent(code), env=env)
     
     def test_basic_call(self):
@@ -64,11 +77,11 @@ class TestTracer(unittest.TestCase):
             bar = objects.bar_from_foo(foo, x=1, y=2)
         """)
         
-        events = self.events
+        events = self.function_events
         self.assertEqual(len(events), 4)
         
         event = events[2]
-        self.assertTrue(isinstance(event, TraceCall))
+        self.assertIsInstance(event, TraceCall)
         self.assertTrue(event.atomic)
         self.assertEqual(event.function, objects.bar_from_foo)
         self.assertEqual(event.module_name, objects.__name__)
@@ -78,7 +91,7 @@ class TestTracer(unittest.TestCase):
         ]))
         
         event = events[3]
-        self.assertTrue(isinstance(event, TraceReturn))
+        self.assertIsInstance(event, TraceReturn)
         self.assertTrue(event.atomic)
         self.assertEqual(event.function, objects.bar_from_foo)
         self.assertEqual(event.module_name, objects.__name__)
@@ -91,11 +104,11 @@ class TestTracer(unittest.TestCase):
             foo = objects.create_foo()
         """)
         
-        events = self.events
+        events = self.function_events
         self.assertEqual(len(events), 2)
         
         event = events[0]
-        self.assertTrue(isinstance(event, TraceCall))
+        self.assertIsInstance(event, TraceCall)
         self.assertTrue(event.atomic)
         self.assertEqual(event.function, objects.create_foo)
         self.assertEqual(event.module_name, objects.__name__)
@@ -103,7 +116,7 @@ class TestTracer(unittest.TestCase):
         self.assertEqual(event.arguments, OrderedDict())
         
         event = events[1]
-        self.assertTrue(isinstance(event, TraceReturn))
+        self.assertIsInstance(event, TraceReturn)
         self.assertTrue(event.atomic)
         self.assertEqual(event.function, objects.create_foo)
         self.assertEqual(event.module_name, objects.__name__)
@@ -117,10 +130,10 @@ class TestTracer(unittest.TestCase):
             foo = objects.nested_create_foo()
         """)
         
-        events = self.events
+        events = self.function_events
         self.assertEqual(len(events), 2)
-        self.assertTrue(isinstance(events[0], TraceCall))
-        self.assertTrue(isinstance(events[1], TraceReturn))
+        self.assertIsInstance(events[0], TraceCall)
+        self.assertIsInstance(events[1], TraceReturn)
         self.assertTrue(events[0].atomic)
         self.assertTrue(events[1].atomic)
         self.assertEqual(events[0].qual_name, 'nested_create_foo')
@@ -136,7 +149,7 @@ class TestTracer(unittest.TestCase):
             baz = objects.baz_from_foo(foo)
         """)
         
-        events = self.events
+        events = self.function_events
         self.assertEqual(len(events), 8)
         self.assertEqual(events[0].qual_name, 'Foo')
         self.assertEqual(events[2].qual_name, 'getattr')
@@ -152,7 +165,7 @@ class TestTracer(unittest.TestCase):
             foo2 = container.foo
         """)
         
-        events = self.events
+        events = self.function_events
         self.assertEqual(len(events), 6)
         self.assertEqual(events[0].qual_name, 'FooContainer')
         self.assertEqual(events[2].qual_name, 'getattr')
@@ -171,7 +184,7 @@ class TestTracer(unittest.TestCase):
             container.foo = objects.Foo()
         """)
         
-        events = self.events
+        events = self.function_events
         self.assertEqual(len(events), 6)
         self.assertEqual(events[0].qual_name, 'FooContainer')
         self.assertEqual(events[2].qual_name, 'Foo')
@@ -185,9 +198,9 @@ class TestTracer(unittest.TestCase):
     def test_boxed_return(self):
         """ Can the tracer pass boxed values from a function return?
         """
-        env = self.trace("objects.bar_from_foo(objects.Foo())")
+        self.trace("objects.bar_from_foo(objects.Foo())")
         
-        events = self.events
+        events = self.function_events
         self.assertEqual(len(events), 4)
         self.assertEqual(events[2].qual_name, 'bar_from_foo')
         self.assertIsInstance(events[2].arguments['foo'], objects.Foo)
@@ -195,6 +208,56 @@ class TestTracer(unittest.TestCase):
         event = events[2].argument_events['foo']
         self.assertIsInstance(event, TraceReturn)
         self.assertEqual(event.qual_name, 'Foo')
+    
+    def test_variable_access(self):
+        """ Are variable accesses traced?
+        """
+        self.trace('x', env={'x': 1})
+
+        events = self.variable_events
+        self.assertEqual(len(events), 1)
+
+        event = events[0]
+        self.assertIsInstance(event, TraceAccess)
+        self.assertEqual(event.name, 'x')
+        self.assertEqual(event.value, 1)
+    
+    def test_variable_assign(self):
+        """ Are variable assignments traced?
+        """
+        self.trace('x = 1')
+
+        events = self.variable_events
+        self.assertEqual(len(events), 1)
+
+        event = events[0]
+        self.assertIsInstance(event, TraceAssign)
+        self.assertEqual(event.names, ['x'])
+        self.assertEqual(event.value, 1)
+    
+    def test_variable_assign_boxed_return(self):
+        """ Can the tracer pass boxed return values to variable assignments?
+        """
+        env = self.trace('foo = objects.Foo()')
+
+        events = self.variable_events
+        event = next(evt for evt in events if isinstance(evt, TraceAssign))
+        self.assertEqual(event.names, ['foo'])
+        self.assertEqual(event.value, env['foo'])
+        self.assertIsInstance(event.value_event, TraceReturn)
+        self.assertEqual(event.value_event.function, objects.Foo)
+    
+    def test_variable_assign_boxed_access(self):
+        """ Can the tracer pass boxed variable values to variable assignments?
+        """
+        self.trace('y = x', env={'x': 1})
+
+        events = self.variable_events
+        self.assertEqual(len(events), 2)
+        self.assertIsInstance(events[0], TraceAccess)
+        self.assertIsInstance(events[1], TraceAssign)
+        self.assertEqual(events[1].value_event, events[0])
+        
 
 
 if __name__ == '__main__':

--- a/flowgraph/trace/trace_event.py
+++ b/flowgraph/trace/trace_event.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 from collections import OrderedDict
 
-from traitlets import HasTraits, Any, Bool, Dict, Instance, List, Unicode
+from traitlets import HasTraits, Any, Bool, Dict, Instance, Int, List, Unicode
 
 from .ast_tracer import BoxedValue
 
@@ -72,7 +72,8 @@ class TraceCall(TraceFunctionEvent):
     """
     
     # Mapping from argument name to argument value.
-    # The ordering of the arguments is that of the function definition.
+    #
+    # The arguments are ordered according to the function definition.
     arguments = Instance(OrderedDict)
 
     # Mapping from argument name to argument's parent event, if any.
@@ -86,10 +87,22 @@ class TraceReturn(TraceFunctionEvent, TraceValueEvent):
     """
     
     # Map from argument name to argument value.
+    #
     # Warning: if an argument has pass-by-reference semantics (as most types
     # in Python do), the argument may be mutated from its state in the 
     # corresponding call event.
     arguments = Instance(OrderedDict)
+
+    # Number of return values, as estimated only by syntax.
+    #
+    # In an ordinary assignment, `x = f()`, or function composition, `g(f())`,
+    # this number will be 1, but in a compound assignment, `x, y = f()`, it will
+    # be greater than 1.
+    #
+    # Note: Python supports multiple return values only implicitly, by returning
+    # tuples or other sequences. Any attempt to determine the "true"  or
+    # "logical" number of return values must ultimately be a heuristic.
+    nvalues = Int(1)
 
 
 class TraceAccess(TraceValueEvent):

--- a/flowgraph/trace/trace_event.py
+++ b/flowgraph/trace/trace_event.py
@@ -115,6 +115,14 @@ class TraceAssign(TraceValueEvent):
     value_event = Instance(TraceValueEvent, allow_none=True)
 
 
+class TraceDelete(TraceEvent):
+    """ Event generated immediately before a variable is deleted.
+    """
+
+    # Names of variables to be deleted.
+    names = List()
+
+
 # XXX: Trait change notifications for `return_value` can lead to FutureWarning
 # from numpy: http://stackoverflow.com/questions/28337085
 import warnings

--- a/flowgraph/trace/trace_event.py
+++ b/flowgraph/trace/trace_event.py
@@ -93,15 +93,18 @@ class TraceReturn(TraceFunctionEvent, TraceValueEvent):
     # corresponding call event.
     arguments = Instance(OrderedDict)
 
-    # Number of return values, as estimated only by syntax.
+    # Number of return values, according to syntactic context.
+    #
+    # Like many programming languages, Python treats function inputs and outputs
+    # asymmetrically. A function can have many arguments, but only one return
+    # value. By convention, multiple return values are represented by returning
+    # a tuple or another sequence type. Because this is a matter of convention,
+    # any attempt to determine the "true"  or "logical" number of return values
+    # must be heuristic.
     #
     # In an ordinary assignment, `x = f()`, or function composition, `g(f())`,
     # this number will be 1, but in a compound assignment, `x, y = f()`, it will
     # be greater than 1.
-    #
-    # Note: Python supports multiple return values only implicitly, by returning
-    # tuples or other sequences. Any attempt to determine the "true"  or
-    # "logical" number of return values must ultimately be a heuristic.
     nvalues = Int(1)
 
 

--- a/flowgraph/trace/trace_event.py
+++ b/flowgraph/trace/trace_event.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 from collections import OrderedDict
 
-from traitlets import HasTraits, Any, Bool, Dict, Instance, Unicode
+from traitlets import HasTraits, Any, Bool, Dict, Instance, List, Unicode
 
 from .ast_tracer import BoxedValue
 
@@ -90,6 +90,29 @@ class TraceReturn(TraceFunctionEvent, TraceValueEvent):
     # in Python do), the argument may be mutated from its state in the 
     # corresponding call event.
     arguments = Instance(OrderedDict)
+
+
+class TraceAccess(TraceValueEvent):
+    """ Event generated immediately after a variable is accessed.
+
+    The variable's value is stored in the `value` attribute.
+    """
+
+    # Name of variable that was accessed.
+    name = Unicode()
+
+
+class TraceAssign(TraceValueEvent):
+    """ Event generated immediately before a variable is assigned.
+
+    The value to be assigned is stored in the `value` attribute.
+    """
+
+    # Names of variables to be assigned.
+    names = List()
+
+    # Parent event of value, if any.
+    value_event = Instance(TraceValueEvent, allow_none=True)
 
 
 # XXX: Trait change notifications for `return_value` can lead to FutureWarning

--- a/flowgraph/trace/tracer.py
+++ b/flowgraph/trace/tracer.py
@@ -21,10 +21,10 @@ import types
 
 from traitlets import HasTraits, Any, Bool, Instance, Int, List
 
-from .ast_tracer import ASTTracer, TraceFunctionCalls
+from .ast_tracer import ASTTracer, ASTTraceTransformer
 from .ast_transform import AttributesToFunctions, IndexingToFunctions, \
     InplaceOperatorsToFunctions, OperatorsToFunctions, \
-    ContainerLiteralsToFunction
+    ContainerLiteralsToFunctions
 from .inspect_function import bind_arguments
 from .inspect_name import get_func_module_name, get_func_qual_name
 from .trace_event import TraceEvent, TraceValueEvent, TraceCall, TraceReturn
@@ -188,8 +188,8 @@ class Tracer(ASTTracer):
             IndexingToFunctions(operator_name),
             OperatorsToFunctions(operator_name),
             InplaceOperatorsToFunctions(operator_name),
-            ContainerLiteralsToFunction('__extra_operator__'),
-            TraceFunctionCalls('__trace__'),
+            ContainerLiteralsToFunctions('__extra_operator__'),
+            ASTTraceTransformer('__trace__'),
         ]
         for transformer in transformers:
             transformer.visit(node)

--- a/flowgraph/trace/tracer.py
+++ b/flowgraph/trace/tracer.py
@@ -158,11 +158,11 @@ class Tracer(ASTTracer):
         scope = _ScopeItem(event=event, emit_events=emit_events)
         self._stack.append(scope)
     
-    def _trace_return(self, return_value):
+    def _trace_return(self, return_value, nvalues):
         """ Called after function returns.
         """
         scope = self._stack.pop()
-        event = self._create_return_event(scope.event, return_value)
+        event = self._create_return_event(scope.event, return_value, nvalues)
         if scope.emit_events:
             self.event = event
         return event
@@ -254,14 +254,14 @@ class Tracer(ASTTracer):
                          module_name=module_name, qual_name=qual_name,
                          arguments=arguments, argument_events=argument_events)
     
-    def _create_return_event(self, call_event, return_value):
+    def _create_return_event(self, call_event, return_value, nvalues):
         """ Create trace event for function return.
         """
         call = call_event
         return TraceReturn(tracer=self, function=call.function,
                            atomic=call.atomic, module_name=call.module_name,
-                           qual_name=call.qual_name, value=return_value,
-                           arguments=call.arguments)
+                           qual_name=call.qual_name, arguments=call.arguments, 
+                           value=return_value, nvalues=nvalues)
 
 
 class _ScopeItem(HasTraits):

--- a/flowgraph/trace/tracer.py
+++ b/flowgraph/trace/tracer.py
@@ -28,7 +28,7 @@ from .ast_transform import AttributesToFunctions, IndexingToFunctions, \
 from .inspect_function import bind_arguments
 from .inspect_name import get_func_module_name, get_func_qual_name
 from .trace_event import TraceEvent, TraceValueEvent, TraceCall, TraceReturn, \
-    TraceAccess, TraceAssign
+    TraceAccess, TraceAssign, TraceDelete
 
 # Modules needed for tracer execution environment.
 import operator
@@ -180,7 +180,7 @@ class Tracer(ASTTracer):
         return value
     
     def _trace_assign(self, names, value):
-        """ Called immediately before a variable is assigned.
+        """ Called before a variable is assigned.
         """
         scope = self._stack[-1]
 
@@ -197,6 +197,13 @@ class Tracer(ASTTracer):
             return event
         
         return value
+    
+    def _trace_delete(self, names):
+        """ Called before a variable is deleted.
+        """
+        scope = self._stack[-1]
+        if scope.emit_events:
+            self.event = TraceDelete(names=names)
     
     # Protected interface
 


### PR DESCRIPTION
The third and final part of #18. At this point, I've implemented all the major static analysis features that I originally wanted. Doubtless minor problems will surface upon further testing, but I consider this little "feature sprint" finished.

The system is now far more reliable than when the tracing was based on `sys.settrace`. We're getting closer to a practically useful system.