### PR TITLE
Support for Python v3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
 install:
   - pip install .[integration_tests]
   - python -m flowgraph.kernel.kernelspec --user

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flow graphs for Python
 
-[![Build Status](https://travis-ci.org/IBM/pyflowgraph.svg?branch=master)](https://travis-ci.org/IBM/pyflowgraph) [![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg)](https://www.python.org/downloads/release/python-270/) [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1401682.svg)](https://doi.org/10.5281/zenodo.1401682)
+[![Build Status](https://travis-ci.org/IBM/pyflowgraph.svg?branch=master)](https://travis-ci.org/IBM/pyflowgraph) [![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg)](https://www.python.org/downloads/release/python-270/) [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/) [![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1401682.svg)](https://doi.org/10.5281/zenodo.1401682)
 
 **Record dataflow graphs of Python programs using dynamic program analysis.**
 

--- a/flowgraph/core/flow_graph_builder.py
+++ b/flowgraph/core/flow_graph_builder.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 
 from collections import deque, OrderedDict
-from copy import deepcopy
 import six
 import sys
 import types
@@ -120,9 +119,14 @@ class FlowGraphBuilder(HasTraits):
         considered primitive. The default implementation allows any object which
         is JSON-able (essentially, the scalar types plus the built-in container
         types if their contents are JSON-able).
-        
-        Note: any objects stored as "value" data will be deep-copied.
         """
+        # Make sure not to modify the passed object.
+        if isinstance(obj, types.GeneratorType):
+            # Do not pass a generator through `json_clean`, as it will convert
+            # it to list, resulting in an empty generator.
+            return False
+        
+        # Default logic: run IPython's `json_clean`.
         try:
             json_clean(obj)
         except ValueError:
@@ -543,7 +547,7 @@ class FlowGraphBuilder(HasTraits):
         
         # Add value if the object is primitive.
         if self.is_primitive(obj):
-            data['value'] = deepcopy(obj)
+            data['value'] = json_clean(obj)
         elif isinstance(obj, types.ModuleType):
             data['value'] = obj.__name__
 

--- a/flowgraph/core/tests/test_flow_graph.py
+++ b/flowgraph/core/tests/test_flow_graph.py
@@ -439,8 +439,8 @@ class TestFlowGraph(unittest.TestCase):
         target.add_node('add', qual_name='add')
         target.add_edge('list', 'min', sourceport='return', targetport='0')
         target.add_edge('list', 'max', sourceport='return', targetport='0')
-        target.add_edge('min', 'add', sourceport='return', targetport='0')
-        target.add_edge('max', 'add', sourceport='return', targetport='1')
+        target.add_edge('min', 'add', sourceport='return', targetport='a')
+        target.add_edge('max', 'add', sourceport='return', targetport='b')
         self.assert_isomorphic(actual, target)
     
     def test_track_inside_list(self):

--- a/flowgraph/integration_tests/test_flow_graph.py
+++ b/flowgraph/integration_tests/test_flow_graph.py
@@ -134,7 +134,7 @@ class IntegrationTestFlowGraph(unittest.TestCase):
         target.add_node('reshape', qual_name='ndarray.reshape')
         target.add_edge('rand', 'shape', sourceport='return', targetport='0',
                         annotation='python/numpy/ndarray')
-        target.add_edge('arange', 'reshape', sourceport='return', targetport='0',
+        target.add_edge('arange', 'reshape', sourceport='return', targetport='self',
                         annotation='python/numpy/ndarray')
         target.add_edge('shape', 'reshape', sourceport='return', targetport='1')
         self.assert_isomorphic(graph, target)
@@ -152,11 +152,11 @@ class IntegrationTestFlowGraph(unittest.TestCase):
         target.add_node('extslice', qual_name='__tuple__')
         target.add_node('getitem', qual_name='getitem')
         target.add_node('gt', qual_name='gt')
-        target.add_edge('rand', 'getitem', sourceport='return', targetport='0',
+        target.add_edge('rand', 'getitem', sourceport='return', targetport='a',
                         annotation='python/numpy/ndarray')
         target.add_edge('slice', 'extslice', sourceport='return', targetport='0')
-        target.add_edge('extslice', 'getitem', sourceport='return', targetport='1')
-        target.add_edge('getitem', 'gt', sourceport='return', targetport='0',
+        target.add_edge('extslice', 'getitem', sourceport='return', targetport='b')
+        target.add_edge('getitem', 'gt', sourceport='return', targetport='a',
                         annotation='python/numpy/ndarray')
         self.assert_isomorphic(graph, target)
     
@@ -172,7 +172,7 @@ class IntegrationTestFlowGraph(unittest.TestCase):
         target.add_node('mul', qual_name='mul')
         target.add_node('linspace', qual_name='linspace')
         target.add_node('sin', qual_name='sin')
-        target.add_edge('pi', 'mul', sourceport='return', targetport='1',
+        target.add_edge('pi', 'mul', sourceport='return', targetport='b',
                         annotation='python/builtins/float')
         target.add_edge('mul', 'linspace', sourceport='return', targetport='stop',
                         annotation='python/builtins/float')
@@ -313,7 +313,7 @@ class IntegrationTestFlowGraph(unittest.TestCase):
                         annotation='python/sklearn/mean-squared-error')
         target.add_edge('read', 'X', sourceport='return', targetport='self',
                         annotation='python/pandas/data-frame')
-        target.add_edge('read', 'y', sourceport='return', targetport='0',
+        target.add_edge('read', 'y', sourceport='return', targetport='a',
                         annotation='python/pandas/data-frame')
         target.add_edge('lm', 'fit', sourceport='return', targetport='self',
                         annotation='python/sklearn/linear-regression')

--- a/flowgraph/trace/tests/test_inspect_function.py
+++ b/flowgraph/trace/tests/test_inspect_function.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 from collections import OrderedDict
 import fractions
+import sys
 import unittest
 
 from ..inspect_function import bind_arguments
@@ -55,7 +56,10 @@ class TestInspectFunctions(unittest.TestCase):
         """
         x = [1,2,3]
         args = bind_arguments(x.append, 4)
-        self.assertEqual(args, OrderedDict([('0',x), ('1',4)]))
+        self.assertEqual(args, OrderedDict([
+            ('self', x),
+            ('object' if sys.version_info >= (3,7) else '1', 4)
+        ]))
     
     def test_bind_var_args(self):
         """ Can we bind *args of a function?

--- a/flowgraph/trace/tests/test_inspect_name.py
+++ b/flowgraph/trace/tests/test_inspect_name.py
@@ -88,7 +88,7 @@ class TestInspectNames(unittest.TestCase):
         """
         # Note: `numpy.random.rand` is a method bound to `mtrand.RandomState`.
         # Try running `import numpy, mtrand`.
-        self.assertEqual(get_func_module_name(np.random.rand), 'mtrand')
+        self.assert_(get_func_module_name(np.random.rand).endswith('mtrand'))
         self.assertEqual(get_func_qual_name(np.random.rand), 'RandomState.rand')
     
     @unittest.skipIf(np is None, "requires numpy")

--- a/setup.py
+++ b/setup.py
@@ -19,15 +19,15 @@ setup_args = {
         'requests',
         'jsonpickle',
         'click',
-        'networkx>=2.0',
+        'networkx<=2.3',
         'cachetools==2.1.0',
-        'blitzdb>=0.3',
+        'blitzdb @ git+https://github.com/epatters/blitzdb.git@py37',
         'sqlalchemy',
         'ipykernel>=4.3.0',
     ],
     'extras_require': {
         'integration_tests': [
-            'numpy',
+            'numpy>=1.16',
             'scipy',
             'pandas',
             'sklearn',


### PR DESCRIPTION
This PR adds support for Python 3.7. A minor release of Python usually shouldn't require any changes, but in this case:

- Python 3.7 improved support for inspecting builtin functions. This is actually a good thing, but it required changes to the inspection code and tests to ensure uniformity across different versions of Python.

- A package we depend on, BlitzDB, is broken on Python 3.7+. Pending a merge of [my PR](https://github.com/adewes/blitzdb/pull/79), I have replaced the dependency with my local branch.